### PR TITLE
Fixed rouding problem on calc of spherical law of cosines.

### DIFF
--- a/src/main/java/com/grum/geocalc/EarthCalc.java
+++ b/src/main/java/com/grum/geocalc/EarthCalc.java
@@ -81,7 +81,12 @@ public class EarthCalc {
         double flat = toRadians(forePoint.latitude);
 
         //spherical law of cosines
-        double c = acos((sin(slat) * sin(flat)) + (cos(slat) * cos(flat) * cos(diffLongitudes)));
+        
+        double sphereCos = (sin(slat) * sin(flat)) + (cos(slat) * cos(flat) * cos(diffLongitudes));
+        if (Math.abs(sphereCos) > 1) {
+        	sphereCos = Math.round(sphereCos);
+        }
+        double c = acos(sphereCos);
 
         return EARTH_DIAMETER * c;
     }

--- a/src/main/java/com/grum/geocalc/EarthCalc.java
+++ b/src/main/java/com/grum/geocalc/EarthCalc.java
@@ -83,10 +83,7 @@ public class EarthCalc {
         //spherical law of cosines
         
         double sphereCos = (sin(slat) * sin(flat)) + (cos(slat) * cos(flat) * cos(diffLongitudes));
-        if (Math.abs(sphereCos) > 1) {
-        	sphereCos = Math.round(sphereCos);
-        }
-        double c = acos(sphereCos);
+        double c = acos(max(min(sphereCos, 1d), -1d));
 
         return EARTH_DIAMETER * c;
     }

--- a/src/test/java/com/grum/geocalc/DistanceTest.java
+++ b/src/test/java/com/grum/geocalc/DistanceTest.java
@@ -125,9 +125,19 @@ public class DistanceTest {
         Coordinate lng = Coordinate.fromDegrees(-0.2912044);
         Point kew = Point.at(lat, lng);
 
-        assertEquals(EarthCalc.gcdDistance(kew, kew), 0, 0);
+        assertEquals(0, EarthCalc.gcdDistance(kew, kew), 0);
     }
 
+    @Test
+    public void testZeroDistanceWaldshutGermany() {
+    	//Kew
+    	Coordinate lat = Coordinate.fromDegrees(47.62285);
+    	Coordinate lng = Coordinate.fromDegrees(8.20897);
+    	Point waldshut = Point.at(lat, lng);
+    	
+    	assertEquals(0, EarthCalc.gcdDistance(waldshut, waldshut), 0);
+    }
+    
     @Test
     public void testBoundingAreaDistance() {
         //Kew


### PR DESCRIPTION
 I had the same calculation in one of my applications and my test colleague found a bug in it. After investigation we found that there was a precision problem wiht the double values that lead to values greater 1 and then to NaN as a result of calling `acos` on it.

I came across your lib while looking for a more robust solution but then found the same "bug". 

So here is proposal to overcome this rounding problem.